### PR TITLE
pushed incorrect version of file for history.js

### DIFF
--- a/api/history.js
+++ b/api/history.js
@@ -1,41 +1,27 @@
 import { createClient } from '@supabase/supabase-js';
-import { INTERSECTIONS } from './intersections.js';
-
 
 const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
 );
-
-async function getFromSupabase(intersection) {
-    // call 
-    const { data, error } =  await supabase 
-    .from('get_intersection_history(instersection)') 
-    .select('*') // which columns 
-
-
-    if (error) throw new Error(`Supabase error: ${error.message}`);
-    return data[0]; // data is an array, you want the first (most recent) row
-
-}
-
-
 
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET');
-  
-  const results = [];
+
+  const name = req.query.intersection;
+
+  if (!name) {
+    return res.status(400).json({ error: 'intersection parameter is required' });
+  }
+
   try {
-    for (const intersection of INTERSECTIONS) {
-      const reading = await getFromSupabase(intersection);
-      if (reading) {
-        reading.lat = intersection.lat;
-        reading.lng = intersection.lng;
-        results.push(reading);
-      }
-    }
-    res.status(200).json(results);
+    const { data, error } = await supabase
+      .rpc('get_intersection_history', { intersection_name: name });
+
+    if (error) throw new Error(`Supabase error: ${error.message}`);
+
+    res.status(200).json(data);
   } catch (err) {
     res.status(500).json({ status: 'error', message: err.message });
   }


### PR DESCRIPTION
## bug was simple wrong version uploaded. However, it is worth documenting the decisions leading to this version

## ISSUE: curl was failing...

**COMMAND TO TEST history.js function failed:**  
`curl "https://tucson-traffic-monitor.vercel.app/api/history?intersection=Speedway%20%26%20Swan"`  
  
**Response:**
<img width="1171" height="30" alt="image" src="https://github.com/user-attachments/assets/6fa5c3b6-0255-4177-9cc4-0e4b670c2b57" />

_{"status":"error","message":"Supabase error: Could not find the table 'public.get_intersection_history(instersection)' in the schema cache"}`_


Set up function in supabase to gather historical data by intersection from calling a query stored in Supabase 
<img width="956" height="355" alt="image" src="https://github.com/user-attachments/assets/1911c17e-67fa-4e38-963b-a1beb72ac084" />
<img width="990" height="362" alt="image" src="https://github.com/user-attachments/assets/1f76bbca-bdee-4ea1-b0fc-1325060727b6" />

history.js calls this function currently on _line 20_:
<img width="852" height="144" alt="image" src="https://github.com/user-attachments/assets/bbb0ffa4-9171-4757-821e-5809fc270b41" />


The corrected response looked like this:
<img width="1889" height="77" alt="image" src="https://github.com/user-attachments/assets/8b321924-76a0-48e0-a146-1696e88f5f1c" />  

_Which is: _  
`[{"day_of_week":0,"time_slot":"2026-03-29T00:00:00+00:00","avg_congestion":0.8036},{"day_of_week":0,"time_slot":"2026-03-29T00:15:00+00:00","avg_congestion":0.738384615384615},{"day_of_week":0,"time_slot":"2026-03-29T00:30:00+00:00","avg_congestion":0.8421},{"day_of_week":0,"time_slot":"2026-03-29T00:45:00+00:00","avg_congestion":0.8276},{"day_of_week":0,"time_slot":"2026-03-29T01:00:00+00:00","avg_congestion":1},{"day_of_week":0,"time_slot":"2026-03-29T01:15:00+00:00","avg_congestion":0.916646153846154},{"day_of_week":0,"time_slot":"2026-03-29T01:30:00+00:00","avg_congestion":0.8276},{"day_of_week":0,"time_slot":"2026-03-29T01:45:00+00:00","avg_congestion":0.8103},{"day_of_week":0,"time_slot":"2026-03-29T02:00:00+00:00","avg_congestion":0.8421},{"day_of_week":0,"time_slot":"2026-03-29T02:15:00+00:00","avg_congestion":0.7679},{"day_of_week":0,"time_slot":"2026-03-29T02:30:00+00:00","avg_congestion":0.7719},{"day_of_week":0,"time_slot":"2026-03-29T02:45:00+00:00","avg_congestion":1},`


